### PR TITLE
Only publish to nuget on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "**" ]
   pull_request:
     branches: [ "main" ]
-  create:
-    tags: [ "*" ]
 
 jobs:
   build:
@@ -84,8 +82,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
-    # Only run for tags being created
-    if: github.event_name == 'create' && startsWith(github.ref, 'refs/tags/')
+    # Only run for main branch
+    if: github.ref == 'refs/heads/main'
 
     steps:
 


### PR DESCRIPTION
Running when a tag is created resulted in the wrong version. Versioning on main is known to be good, so we'll publish from commits to that.