### PR TITLE
Custom row action visibility

### DIFF
--- a/Mimeo.DynamicUI.Blazor/FormFields/DynamicField.cs
+++ b/Mimeo.DynamicUI.Blazor/FormFields/DynamicField.cs
@@ -9,6 +9,7 @@ public class DynamicField : ComponentBase
     private static readonly Dictionary<FormFieldType, Type> formFieldTypeMap = new()
     {
         { FormFieldType.Text, typeof(TextField) },
+        { FormFieldType.Combobox, typeof(TextField) },
         { FormFieldType.Checkbox, typeof(CheckboxField) },
         { FormFieldType.SingleSelect, typeof(SingleSelectField) },
         { FormFieldType.MultiSelect, typeof(MultiSelectField) },
@@ -22,7 +23,12 @@ public class DynamicField : ComponentBase
         { FormFieldType.DateTime, typeof(DateTimeField) },
         { FormFieldType.Integer, typeof(IntegerField) },
         { FormFieldType.Decimal, typeof(DecimalField) },
+#pragma warning disable CS0618 // Type or member is obsolete (Justification: Backwards compatibility)
         { FormFieldType.List, typeof(ListField<>) },
+#pragma warning restore CS0618 // Type or member is obsolete
+        { FormFieldType.Table, typeof(ListField<>) },
+        { FormFieldType.SectionList, typeof(ListField<>) },
+        { FormFieldType.ReorderableSectionList, typeof(ListField<>) },
         { FormFieldType.Nullable, typeof(NullableFormField) },
         { FormFieldType.Guid, typeof(GuidFormField) }
     };
@@ -118,7 +124,7 @@ public class DynamicField : ComponentBase
         builder.CloseComponent();
     }
 
-    private bool InheritsFormFieldBase(Type type)
+    private static bool InheritsFormFieldBase(Type type)
     {
         // The built-in methods don't support unbound generics (or I haven't found the correct one yet)
 

--- a/Mimeo.DynamicUI.Blazor/FormFields/ListField.razor
+++ b/Mimeo.DynamicUI.Blazor/FormFields/ListField.razor
@@ -5,7 +5,7 @@
 @typeparam T
 @inherits FormFieldBase<List<T>>
 
-@if (!wrapInViewModel && ListDefinition?.PresentationMode == ListFieldPresentationMode.SectionList)
+@if (!wrapInViewModel && ListDefinition?.Type == FormFieldType.SectionList)
 {
     if (ReadOnly)
     {
@@ -56,7 +56,7 @@
         <RadzenButton Icon="add_circle_outline" style="margin-top:1em;margin-bottom:1em;" Text="@lang.GetValueOrDefault("add")" Click="() => OnCreate(CreateViewModel())" />
     }
 }
-else if (!wrapInViewModel && ListDefinition?.PresentationMode == ListFieldPresentationMode.ReorderableSectionList)
+else if (!wrapInViewModel && ListDefinition?.Type == FormFieldType.ReorderableSectionList)
 {
     if (ReadOnly)
     {

--- a/Mimeo.DynamicUI.Blazor/Forms/ODataGrid.razor.cs
+++ b/Mimeo.DynamicUI.Blazor/Forms/ODataGrid.razor.cs
@@ -428,7 +428,7 @@ public partial class ODataGrid
     }
     private bool GetActionsMenuVisibility()
     {
-        return CanCopy || CanUpdate || CanView || CanDelete;
+        return CanCopy || CanUpdate || CanView || CanDelete || CustomRowActions.Any();
     }
 
     private GridItem CreateGridItem(ViewModel listModel)

--- a/Mimeo.DynamicUI.Demo/Mimeo.DynamicUI.Demo.Shared/ViewModels/TestViewModel.cs
+++ b/Mimeo.DynamicUI.Demo/Mimeo.DynamicUI.Demo.Shared/ViewModels/TestViewModel.cs
@@ -280,7 +280,7 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
             }
         }
 
-        public class AdvancedSubViewModel : ViewModel, INotifyPropertyChanged
+        public class AdvancedSubViewModel : ViewModel
         {
             public string? Property1
             {

--- a/Mimeo.DynamicUI.Demo/Mimeo.DynamicUI.Demo.Shared/ViewModels/TestViewModel.cs
+++ b/Mimeo.DynamicUI.Demo/Mimeo.DynamicUI.Demo.Shared/ViewModels/TestViewModel.cs
@@ -144,7 +144,7 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
             yield return FormField(() => Number);
             yield return FormField(() => Decimal);
             yield return FormField(() => DateTimeUtc, dateDisplayMode: DateDisplayMode.UserLocal);
-            yield return FormField(() => StringList);
+            yield return Table(() => StringList);
         }
 
         protected override IEnumerable<FormFieldDefinition> GetDropDownListFormFields()
@@ -185,13 +185,13 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
             yield return FormField(() => ComboBox, textType: TextType.SingleLine, items: ["Option 1", "option2languagekey", "Option 3"]);
             yield return new FormFieldDefinition(FormFieldType.Color, () => Color);
             yield return FormField(() => Section);
-            yield return FormField(() => StringList);
+            yield return Table(() => StringList);
 
             // Depending on the structure of the view model, sometimes a table is more appropriate
-            yield return FormField(() => SimpleModelList, mode: ListFieldPresentationMode.Table);
+            yield return Table(() => SimpleModelList);
 
             // but for sufficiently large view models, a section list is easier on the user
-            yield return FormField(() => AdvancedModelList, m => m.FormField(() => m.Property1), mode: ListFieldPresentationMode.SectionList);
+            yield return SectionList(() => AdvancedModelList, m => m.FormField(() => m.Property1));
 
             yield return new SingleSelectDropDownFormFieldDefinition(() => RelatedModelId, relatedModelsSource, FormField(() => Name), idField);
             yield return new MultiSelectDropDownFormFieldDefinition(() => RelatedModelIds, relatedModelsSource, FormField(() => Name), idField);
@@ -233,9 +233,9 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
             yield return FormField(() => ComboBox, textType: TextType.SingleLine, items: ["Option 1", "option2languagekey", "Option 3"]);
             yield return new FormFieldDefinition(FormFieldType.Color, () => Color);
             yield return FormField(() => Section);
-            yield return FormField(() => StringList);
-            yield return FormField(() => SimpleModelList);
-            yield return FormField(() => AdvancedModelList);
+            yield return Table(() => StringList);
+            yield return Table(() => SimpleModelList);
+            yield return SectionList(() => AdvancedModelList);
             yield return FormField(() => Enabled);
             yield return new NullableFormFieldDefinition(() => NullableStringEnabled, FormField(() => NullableStringValue));
             yield return new FormFieldDefinition(FormFieldType.Checkbox, () => EnableHiddenProperties)
@@ -249,7 +249,7 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
 
         }
 
-        public class SimpleSubViewModel : ViewModel, INotifyPropertyChanged
+        public class SimpleSubViewModel : ViewModel
         {
             public string? Property1
             {
@@ -257,7 +257,7 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
                 set
                 {
                     _property1 = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Property1)));
+                    RaisePropertyChanged(nameof(Property1));
                 }
             }
             private string? _property1;
@@ -268,13 +268,10 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
                 set
                 {
                     _property2 = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Property2)));
+                    RaisePropertyChanged(nameof(Property2));
                 }
             }
             private int _property2;
-
-            // INotifyPropertyChanged is partially supported by the UI, and is generally not required, but can be useful in niche situations
-            public event PropertyChangedEventHandler? PropertyChanged;
 
             protected override IEnumerable<FormFieldDefinition> GetEditFormFields()
             {
@@ -291,7 +288,7 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
                 set
                 {
                     _property1 = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Property1)));
+                    RaisePropertyChanged(nameof(Property1));
                 }
             }
             private string? _property1;
@@ -302,21 +299,18 @@ namespace Mimeo.DynamicUI.Demo.Shared.ViewModels
                 set
                 {
                     _property2 = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Property2)));
+                    RaisePropertyChanged(nameof(Property2));
                 }
             }
             private int _property2;
 
             public List<string> SubList { get; set; } = [];
 
-            // INotifyPropertyChanged is partially supported by the UI, and is generally not required, but can be useful in niche situations
-            public event PropertyChangedEventHandler? PropertyChanged;
-
             protected override IEnumerable<FormFieldDefinition> GetEditFormFields()
             {
                 yield return FormField(() => Property1);
                 yield return FormField(() => Property2);
-                yield return FormField(() => SubList);
+                yield return Table(() => SubList);
             }
         }
 

--- a/Mimeo.DynamicUI/Data/OData/ODataExpressionGenerator.cs
+++ b/Mimeo.DynamicUI/Data/OData/ODataExpressionGenerator.cs
@@ -120,7 +120,12 @@ namespace Mimeo.DynamicUI.Data.OData
                         DataFilterOperator.GreaterThan,
                         DataFilterOperator.GreaterThanOrEquals
                     };
+#pragma warning disable CS0618 // Type or member is obsolete (Justification: Backwards compatibility)
                 case FormFieldType.List:
+#pragma warning restore CS0618 // Type or member is obsolete
+                case FormFieldType.Table:
+                case FormFieldType.SectionList:
+                case FormFieldType.ReorderableSectionList:
                     var sampleItem = (filter.FormFieldDefinition as IListFieldDefinition)?.CreateNewItem();
                     if (sampleItem is ViewModel)
                     {

--- a/Mimeo.DynamicUI/FormFieldDefinition.cs
+++ b/Mimeo.DynamicUI/FormFieldDefinition.cs
@@ -132,6 +132,8 @@ namespace Mimeo.DynamicUI
 
         public string LanguageKey { get; set; }
 
+        public string DescriptionLanguageKey => LanguageKey + "_desc";
+
         public Type PropertyType { get; set; }
 
         public Type? FilterType { get; set; }

--- a/Mimeo.DynamicUI/FormFieldType.cs
+++ b/Mimeo.DynamicUI/FormFieldType.cs
@@ -3,22 +3,79 @@
     public enum FormFieldType
     {
         Hidden = 0,
-        Text,
+
+        /// <summary>
+        /// A field that accepts user-entered text
+        /// </summary>
+        Text, 
+
+        /// <summary>
+        /// A field that accepts user-entered text but presents some pre-defined values
+        /// </summary>
+        Combobox,
+
         Checkbox,
+
+        /// <summary>
+        /// A field that presents the user with pre-defined value and allows selection of a single value
+        /// </summary>
         SingleSelect,
+
+        /// <summary>
+        /// A field that presents the user with a dropdown to select a single pre-defined value
+        /// </summary>
         SingleSelectDropdown,
+
+        /// <summary>
+        /// A field that presents the user with a dropdown to select a single value from a data source
+        /// </summary>
         SingleSelectDataSourceDropdown,
+
+        /// <summary>
+        /// A field that presents the user with pre-defined value and allows selection of multiple values
+        /// </summary>
         MultiSelect,
+
+        /// <summary>
+        /// A field that presents the user with a dropdown to select one or more pre-defined values
+        /// </summary>
         MultiSelectDropdown,
+
+        /// <summary>
+        /// A field that presents the user with values that come from a data source and allows selection of multiple values
+        /// </summary>
         MultiSelectDataSourceDropdown,
+
         Date,
         Time,
         DateTime,
         Color,
         Integer,
-        Decimal,
+        Decimal, 
+
+        [Obsolete("Use Table, SectionList, or ReorderableSectionList instead")]
         List,
+
+        /// <summary>
+        /// Presents a list of items or view models in a table
+        /// </summary>
+        Table,
+
+        /// <summary>
+        /// Presents a list of items or view models as a sequential list of sub-editors
+        /// </summary>
+        SectionList,
+
+        /// <summary>
+        /// Presents a list of items or view models as a sequential list of sub-editors, with the ability to reorder items
+        /// </summary>
+        ReorderableSectionList,
+
+        /// <summary>
+        /// Presents another form field, wrapped with a checkbox that is meant to indicate whether the value is null
+        /// </summary>
         Nullable,
+
         Guid,
         Section,
         Custom

--- a/Mimeo.DynamicUI/ListFieldDefinition.cs
+++ b/Mimeo.DynamicUI/ListFieldDefinition.cs
@@ -10,16 +10,54 @@ namespace Mimeo.DynamicUI
 
     public class ListFieldDefinition<T> : FormFieldDefinition, IListFieldDefinition
     {
+        [Obsolete("Use overload with FormFieldType instead")]
         public ListFieldDefinition(Expression<Func<List<T>>> @for)
             : base(FormFieldType.List, LinqExtensions.Cast<List<T>, object?>(@for))
         {
+        }
+
+        public ListFieldDefinition(FormFieldType formFieldType, Expression<Func<List<T>>> @for)
+            : base(formFieldType, LinqExtensions.Cast<List<T>, object?>(@for))
+        {
+            switch (formFieldType)
+            {
+                case FormFieldType.Table:
+                case FormFieldType.SectionList:
+                case FormFieldType.ReorderableSectionList:
+                    break;
+                default:
+                    throw new ArgumentException("formFieldType must be Table, SectionList, or ReorderableSectionList", nameof(formFieldType));
+            }
         }
 
         public FormFieldType? ItemFormFieldType { get; set; }
 
         public Func<T>? NewItemCreator { get; set; }
 
-        public ListFieldPresentationMode PresentationMode { get; set; } = ListFieldPresentationMode.Table;
+        [Obsolete("Differentiate using FormFieldType instead")]
+        public ListFieldPresentationMode PresentationMode
+        {
+            get => _presentationMode;
+            set
+            {
+                _presentationMode = value;
+                if (_presentationMode == ListFieldPresentationMode.Table)
+                {
+                    this.Type = FormFieldType.Table;
+                }
+                else if (_presentationMode == ListFieldPresentationMode.SectionList)
+                {
+                    this.Type = FormFieldType.SectionList;
+                }
+                else if (_presentationMode == ListFieldPresentationMode.ReorderableSectionList)
+                {
+                    this.Type = FormFieldType.ReorderableSectionList;
+                }
+            }
+        }
+
+        [Obsolete("Differentiate using FormFieldType instead")]
+        private ListFieldPresentationMode _presentationMode = ListFieldPresentationMode.Table;
 
         /// <summary>
         /// For use with <see cref="PresentationMode"/> equal to <see cref="ListFieldPresentationMode.SectionList"/> or <see cref="ListFieldPresentationMode.ReorderableSectionList"/>,
@@ -50,6 +88,7 @@ namespace Mimeo.DynamicUI
         object? IListFieldDefinition.CreateNewItem() => CreateNewItem();
     }
 
+    [Obsolete("Differentiate using FormFieldType instead")]
     public enum ListFieldPresentationMode
     {
         Table,

--- a/Mimeo.DynamicUI/TextFieldDefinition.cs
+++ b/Mimeo.DynamicUI/TextFieldDefinition.cs
@@ -41,6 +41,22 @@ namespace Mimeo.DynamicUI
         /// <summary>
         /// An optional set of values that can be selected as a combobox. Requires <see cref="TextType"/> to be <see cref="DynamicUI.TextType.SingleLine"/>.
         /// </summary>
-        public List<string>? Items { get; set; }
+        public List<string>? Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+
+                if (value != null && value.Count > 0)
+                {
+                    // Backwards compatibility for when Items was just an option under a Text form field type
+                    Type = FormFieldType.Combobox;
+                }
+            }
+        }
+        private List<string>? _items;
+
+        public bool MultiLine => TextType != TextType.SingleLine;
     }
 }

--- a/Mimeo.DynamicUI/ViewModel.cs
+++ b/Mimeo.DynamicUI/ViewModel.cs
@@ -1,11 +1,19 @@
 ﻿using Mimeo.DynamicUI.Data;
 using Mimeo.DynamicUI.Extensions;
+using System.ComponentModel;
 using System.Linq.Expressions;
 
 namespace Mimeo.DynamicUI
 {
-    public abstract class ViewModel
+    public abstract class ViewModel : INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
         public virtual object? GetValue(FormFieldDefinition field)
         {
             var property = this.GetType().GetProperty(field.PropertyName);
@@ -26,7 +34,8 @@ namespace Mimeo.DynamicUI
             }
 
             property.SetValue(this, value);
-            field?.OnValueChanged?.Invoke(value);
+            field.OnValueChanged?.Invoke(value);
+            RaisePropertyChanged(field.PropertyName);
         }
 
         /// <summary>
@@ -109,7 +118,10 @@ namespace Mimeo.DynamicUI
         /// <summary>
         /// Gets fields that should show up in an edit form for a single view model
         /// </summary>
-        protected abstract IEnumerable<FormFieldDefinition> GetEditFormFields();
+        protected virtual IEnumerable<FormFieldDefinition> GetEditFormFields()
+        {
+            return Enumerable.Empty<FormFieldDefinition>();
+        }
 
         public FormFieldDefinition FormField(FormFieldType type, Expression<Func<object?>> @for, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null)
         {
@@ -237,6 +249,7 @@ namespace Mimeo.DynamicUI
             }.WithCustomLanguageKey(customLanguageKey);
         }
 
+        [Obsolete("Use Table(...), SectionList(...), or ReorderableSectionList(...) instead")]
         public FormFieldDefinition FormField<T>(Expression<Func<List<T>>> @for, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<T>? newItemCreator = null, ListFieldPresentationMode? mode = null)
         {
             return new ListFieldDefinition<T>(@for)
@@ -251,6 +264,7 @@ namespace Mimeo.DynamicUI
             }.WithCustomLanguageKey(customLanguageKey);
         }
 
+        [Obsolete("Use Table(...), SectionList(...), or ReorderableSectionList(...) instead")]
         public FormFieldDefinition FormField<TViewModel>(Expression<Func<List<TViewModel>>> @for, Func<TViewModel, FormFieldDefinition> headerField, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<TViewModel>? newItemCreator = null, ListFieldPresentationMode? mode = null)
         {
             return new ListFieldDefinition<TViewModel>(@for)
@@ -262,6 +276,87 @@ namespace Mimeo.DynamicUI
                 Filterable = filterable,
                 NewItemCreator = newItemCreator,
                 PresentationMode = mode ?? ListFieldPresentationMode.ReorderableSectionList,
+                HeaderField = headerField
+            }.WithCustomLanguageKey(customLanguageKey);
+        }
+
+        public FormFieldDefinition Table<T>(Expression<Func<List<T>>> @for, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<T>? newItemCreator = null)
+        {
+            return new ListFieldDefinition<T>(FormFieldType.Table, @for)
+            {
+                ReadOnly = readOnly,
+                Sortable = sortable,
+                Collapsed = collapsed,
+                DefaultSortDirection = defaultSort,
+                Filterable = filterable,
+                NewItemCreator = newItemCreator
+            }.WithCustomLanguageKey(customLanguageKey);
+        }
+
+        public FormFieldDefinition Table<TViewModel>(Expression<Func<List<TViewModel>>> @for, Func<TViewModel, FormFieldDefinition> headerField, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<TViewModel>? newItemCreator = null)
+        {
+            return new ListFieldDefinition<TViewModel>(FormFieldType.Table, @for)
+            {
+                ReadOnly = readOnly,
+                Sortable = sortable,
+                Collapsed = collapsed,
+                DefaultSortDirection = defaultSort,
+                Filterable = filterable,
+                NewItemCreator = newItemCreator,
+                HeaderField = headerField
+            }.WithCustomLanguageKey(customLanguageKey);
+        }
+
+        public FormFieldDefinition SectionList<T>(Expression<Func<List<T>>> @for, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<T>? newItemCreator = null)
+        {
+            return new ListFieldDefinition<T>(FormFieldType.SectionList, @for)
+            {
+                ReadOnly = readOnly,
+                Sortable = sortable,
+                Collapsed = collapsed,
+                DefaultSortDirection = defaultSort,
+                Filterable = filterable,
+                NewItemCreator = newItemCreator
+            }.WithCustomLanguageKey(customLanguageKey);
+        }
+
+        public FormFieldDefinition SectionList<TViewModel>(Expression<Func<List<TViewModel>>> @for, Func<TViewModel, FormFieldDefinition> headerField, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<TViewModel>? newItemCreator = null)
+        {
+            return new ListFieldDefinition<TViewModel>(FormFieldType.SectionList, @for)
+            {
+                ReadOnly = readOnly,
+                Sortable = sortable,
+                Collapsed = collapsed,
+                DefaultSortDirection = defaultSort,
+                Filterable = filterable,
+                NewItemCreator = newItemCreator,
+                HeaderField = headerField
+            }.WithCustomLanguageKey(customLanguageKey);
+        }
+
+        public FormFieldDefinition ReorderableSectionList<T>(Expression<Func<List<T>>> @for, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<T>? newItemCreator = null)
+        {
+            return new ListFieldDefinition<T>(FormFieldType.SectionList, @for)
+            {
+                ReadOnly = readOnly,
+                Sortable = sortable,
+                Collapsed = collapsed,
+                DefaultSortDirection = defaultSort,
+                Filterable = filterable,
+                NewItemCreator = newItemCreator
+            }.WithCustomLanguageKey(customLanguageKey);
+        }
+
+        public FormFieldDefinition ReorderableSectionList<TViewModel>(Expression<Func<List<TViewModel>>> @for, Func<TViewModel, FormFieldDefinition> headerField, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<TViewModel>? newItemCreator = null)
+        {
+            return new ListFieldDefinition<TViewModel>(FormFieldType.SectionList, @for)
+            {
+                ReadOnly = readOnly,
+                Sortable = sortable,
+                Collapsed = collapsed,
+                DefaultSortDirection = defaultSort,
+                Filterable = filterable,
+                NewItemCreator = newItemCreator,
                 HeaderField = headerField
             }.WithCustomLanguageKey(customLanguageKey);
         }

--- a/Mimeo.DynamicUI/ViewModel.cs
+++ b/Mimeo.DynamicUI/ViewModel.cs
@@ -336,7 +336,7 @@ namespace Mimeo.DynamicUI
 
         public FormFieldDefinition ReorderableSectionList<T>(Expression<Func<List<T>>> @for, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<T>? newItemCreator = null)
         {
-            return new ListFieldDefinition<T>(FormFieldType.SectionList, @for)
+            return new ListFieldDefinition<T>(FormFieldType.ReorderableSectionList, @for)
             {
                 ReadOnly = readOnly,
                 Sortable = sortable,
@@ -349,7 +349,7 @@ namespace Mimeo.DynamicUI
 
         public FormFieldDefinition ReorderableSectionList<TViewModel>(Expression<Func<List<TViewModel>>> @for, Func<TViewModel, FormFieldDefinition> headerField, bool readOnly = false, bool sortable = true, bool collapsed = false, SortDirection defaultSort = SortDirection.None, bool filterable = true, string? customLanguageKey = null, Func<TViewModel>? newItemCreator = null)
         {
-            return new ListFieldDefinition<TViewModel>(FormFieldType.SectionList, @for)
+            return new ListFieldDefinition<TViewModel>(FormFieldType.ReorderableSectionList, @for)
             {
                 ReadOnly = readOnly,
                 Sortable = sortable,


### PR DESCRIPTION
- Fix custom row actions not being shown in ODataGrid if no other non-custom actions are shown
- Misc refactors to make it easier to add support for UI frameworks other than Blazor